### PR TITLE
Update Paypal.php

### DIFF
--- a/Paypal.php
+++ b/Paypal.php
@@ -7,7 +7,7 @@
  * @see https://developer.paypal.com/webapps/developer/applications/accounts
  */
 
-namespace marciocamello\yii2-paypal;
+namespace marciocamello\yii2\paypal;
 
 define('PP_CONFIG_PATH', __DIR__);
 


### PR DESCRIPTION
Error in PHP 5.5.12 Parse error: syntax error, unexpected '-', expecting \ (T_NS_SEPARATOR) or ';' or '{' in D:\wamp\www\yesbootstrap\vendor\marciocamello\yii2-paypal\Paypal.php on line 10
